### PR TITLE
feat: remove AWS user

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -164,19 +164,22 @@ resource "google_service_account_key" "prow_terraform" {
 
 ### AWS Service Account for terraform 
 resource "aws_iam_user" "prow_terraform" {
+  count = var.create_aws_terraform_user == true ? 1 : 0
   name = "tf_aws_service_account_${local.infra_id}"
   tags = local.tags
 }
 
 ### AWS Service Account access key
 resource "aws_iam_access_key" "prow_terraform" {
-  user = aws_iam_user.prow_terraform.name
+  count = var.create_aws_terraform_user == true ? 1 : 0
+  user = aws_iam_user.prow_terraform[count.index].name
 }
 
 ### AWS Service Account IAM policy
 resource "aws_iam_user_policy" "prow_terraform" {
+  count = var.create_aws_terraform_user == true ? 1 : 0
   name = "tf_aws_service_account_${local.infra_id}"
-  user = aws_iam_user.prow_terraform.name
+  user = aws_iam_user.prow_terraform[count.index].name
 
   policy = <<EOF
 {

--- a/main.tf
+++ b/main.tf
@@ -170,13 +170,13 @@ resource "aws_iam_user" "prow_terraform" {
 
 ### AWS Service Account access key
 resource "aws_iam_access_key" "prow_terraform" {
-  user = "${aws_iam_user.prow_terraform.name}"
+  user = aws_iam_user.prow_terraform.name
 }
 
 ### AWS Service Account IAM policy
 resource "aws_iam_user_policy" "prow_terraform" {
   name = "tf_aws_service_account_${local.infra_id}"
-  user = "${aws_iam_user.prow_terraform.name}"
+  user = aws_iam_user.prow_terraform.name
 
   policy = <<EOF
 {

--- a/main.tf
+++ b/main.tf
@@ -162,38 +162,41 @@ resource "google_service_account_key" "prow_terraform" {
   service_account_id = google_service_account.prow_terraform.name
 }
 
-### AWS Service Account for terraform 
-resource "aws_iam_user" "prow_terraform" {
-  count = var.create_aws_terraform_user == true ? 1 : 0
-  name = "tf_aws_service_account_${local.infra_id}"
-  tags = local.tags
-}
+# Removing the AWS user management - this is not directly related to this module 
+# and it cleaner without it
+#
+# ### AWS Service Account for terraform 
+# resource "aws_iam_user" "prow_terraform" {
+#   count = var.create_aws_terraform_user == true ? 1 : 0
+#   name = "tf_aws_service_account_${local.infra_id}"
+#   tags = local.tags
+# }
 
-### AWS Service Account access key
-resource "aws_iam_access_key" "prow_terraform" {
-  count = var.create_aws_terraform_user == true ? 1 : 0
-  user = aws_iam_user.prow_terraform[count.index].name
-}
+# ### AWS Service Account access key
+# resource "aws_iam_access_key" "prow_terraform" {
+#   count = var.create_aws_terraform_user == true ? 1 : 0
+#   user = aws_iam_user.prow_terraform[count.index].name
+# }
 
-### AWS Service Account IAM policy
-resource "aws_iam_user_policy" "prow_terraform" {
-  count = var.create_aws_terraform_user == true ? 1 : 0
-  name = "tf_aws_service_account_${local.infra_id}"
-  user = aws_iam_user.prow_terraform[count.index].name
+# ### AWS Service Account IAM policy
+# resource "aws_iam_user_policy" "prow_terraform" {
+#   count = var.create_aws_terraform_user == true ? 1 : 0
+#   name = "tf_aws_service_account_${local.infra_id}"
+#   user = aws_iam_user.prow_terraform[count.index].name
 
-  policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": "*",
-            "Resource": "*"
-        }
-    ]
-}
-EOF
-}
+#   policy = <<EOF
+# {
+#     "Version": "2012-10-17",
+#     "Statement": [
+#         {
+#             "Effect": "Allow",
+#             "Action": "*",
+#             "Resource": "*"
+#         }
+#     ]
+# }
+# EOF
+# }
 
 ### DNS Zone for the Base Domain we are using
 resource "google_dns_managed_zone" "cluster_zone" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -11,10 +11,10 @@ output "prow_bucket_svc_account_key" {
   sensitive = true
 }
 
-# output "prow_terraform_gcloud_svc_account_key" {
-#   value     = google_service_account_key.prow_terraform.private_key
-#   sensitive = true
-# }
+output "prow_terraform_gcloud_svc_account_key" {
+  value     = google_service_account_key.prow_terraform.private_key
+  sensitive = true
+}
 
 # output "prow_terraform_aws_svc_account_access_key_id" {
 #   value     = aws_iam_access_key.prow_terraform[*].id

--- a/outputs.tf
+++ b/outputs.tf
@@ -17,12 +17,12 @@ output "prow_terraform_gcloud_svc_account_key" {
 }
 
 output "prow_terraform_aws_svc_account_access_key_id" {
-  value     = aws_iam_access_key.prow_terraform.id
+  value     = aws_iam_access_key.prow_terraform[*].id
   sensitive = true
 }
 
 output "prow_terraform_aws_svc_account_secret_access_key" {
-  value     = aws_iam_access_key.prow_terraform.secret
+  value     = aws_iam_access_key.prow_terraform[*].secret
   sensitive = true
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -11,20 +11,20 @@ output "prow_bucket_svc_account_key" {
   sensitive = true
 }
 
-output "prow_terraform_gcloud_svc_account_key" {
-  value     = google_service_account_key.prow_terraform.private_key
-  sensitive = true
-}
+# output "prow_terraform_gcloud_svc_account_key" {
+#   value     = google_service_account_key.prow_terraform.private_key
+#   sensitive = true
+# }
 
-output "prow_terraform_aws_svc_account_access_key_id" {
-  value     = aws_iam_access_key.prow_terraform[*].id
-  sensitive = true
-}
+# output "prow_terraform_aws_svc_account_access_key_id" {
+#   value     = aws_iam_access_key.prow_terraform[*].id
+#   sensitive = true
+# }
 
-output "prow_terraform_aws_svc_account_secret_access_key" {
-  value     = aws_iam_access_key.prow_terraform[*].secret
-  sensitive = true
-}
+# output "prow_terraform_aws_svc_account_secret_access_key" {
+#   value     = aws_iam_access_key.prow_terraform[*].secret
+#   sensitive = true
+# }
 
 output "prow_artefacts_bucket_name" {
   value = google_storage_bucket.prow_bucket.name

--- a/variables.tf
+++ b/variables.tf
@@ -162,6 +162,10 @@ variable "base_domain" {
   type = string
 }
 
+variable "create_aws_terraform_user" {
+  type = bool
+}
+
 variable "google_apis"{
   type = set(string)
   default = [

--- a/variables.tf
+++ b/variables.tf
@@ -164,6 +164,7 @@ variable "base_domain" {
 
 variable "create_aws_terraform_user" {
   type = bool
+  default = true
 }
 
 variable "google_apis"{

--- a/variables.tf
+++ b/variables.tf
@@ -162,11 +162,6 @@ variable "base_domain" {
   type = string
 }
 
-variable "create_aws_terraform_user" {
-  type = bool
-  default = true
-}
-
 variable "google_apis"{
   type = set(string)
   default = [


### PR DESCRIPTION
- Also, remove Interpolation only expressions  warnings

```

Warning: Interpolation-only expressions are deprecated

  on .terraform/modules/prow-cluster/main.tf line 173, in resource "aws_iam_access_key" "prow_terraform":
 173:   user = "${aws_iam_user.prow_terraform.name}"

Terraform 0.11 and earlier required all non-constant expressions to be
provided via interpolation syntax, but this pattern is now deprecated. To
silence this warning, remove the "${ sequence from the start and the }"
sequence from the end of this expression, leaving just the inner expression.

Template interpolation syntax is still used to construct strings from
expressions when the template includes multiple interpolation sequences or a
mixture of literal strings and interpolations. This deprecation applies only
to templates that consist entirely of a single interpolation sequence.


Warning: Interpolation-only expressions are deprecated

  on .terraform/modules/prow-cluster/main.tf line 179, in resource "aws_iam_user_policy" "prow_terraform":
 179:   user = "${aws_iam_user.prow_terraform.name}"

Terraform 0.11 and earlier required all non-constant expressions to be
provided via interpolation syntax, but this pattern is now deprecated. To
silence this warning, remove the "${ sequence from the start and the }"
sequence from the end of this expression, leaving just the inner expression.

Template interpolation syntax is still used to construct strings from
expressions when the template includes multiple interpolation sequences or a
mixture of literal strings and interpolations. This deprecation applies only
to templates that consist entirely of a single interpolation sequence.
```